### PR TITLE
R20- typos and compatibility

### DIFF
--- a/src/main/resources/static/js/character.js
+++ b/src/main/resources/static/js/character.js
@@ -1144,7 +1144,7 @@ var skillLookup = {
     "GeneralEducation": "generalEdu",
     "MedicineEducation": "medicineEdu",
     "OccultEducation": "occultEdu",
-    "PokeEducation": "pokemonEdu",
+    "PokemonEducation": "pokemonEdu",
     "TechnologyEducation": "techEdu",
     "Focus": "focus",
     "Guile": "guile",
@@ -1158,6 +1158,7 @@ var skillLookup = {
 function buildRoll20Json() {
 
     var json = {
+        "EXPORTER_VERSION": "Pokesheets",
         "CharType": 0,
         "nickname": $("#char-name").val(),
         "species": $("#char-species").val(),
@@ -1197,7 +1198,7 @@ function buildRoll20Json() {
         "GeneralEducation": 1,
         "MedicineEducation": 1,
         "OccultEducation": 1,
-        "PokeEducation": 1,
+        "PokemonEducation": 1,
         "TechnologyEducation": 1,
         "Focus": 2,
         "Guile": 2,
@@ -1215,7 +1216,7 @@ function buildRoll20Json() {
         "GeneralEducation_bonus": 0,
         "MedicineEducation_bonus": 0,
         "OccultEducation_bonus": 0,
-        "PokeEducation_bonus": 0,
+        "PokemonEducation_bonus": 0,
         "TechnologyEducation_bonus": 0,
         "Focus_bonus": 0,
         "Guile_bonus": 0,
@@ -1326,9 +1327,9 @@ function buildRoll20Json() {
 
     $(".form-ability").each(function(JQAbility) {
         var x = $(".form-ability")[JQAbility].id.split("-")[1]
-
         var aname = "#ability-"+x+"-"
-        json["Ability"+x] = {
+
+        json["Ability"+(parseInt(x)+1).toString()] = {
             "Name": $(aname+"name").val(),
             "Freq": $(aname+"freq").val(),
             "Target": $(aname+"target").val(),
@@ -1339,9 +1340,9 @@ function buildRoll20Json() {
 
     $(".form-pokeedge").each(function(JQEdge) {
         var x = $(".form-pokeedge")[JQEdge].id.split("-")[1]
-
         var ename = "#pokeedge-"+x+"-"
-        json["PokeEdge"+x] = {
+
+        json["PokeEdge"+(parseInt(x)+1).toString()] = {
             "Name": $(ename+"name").val(),
             "Cost": $(ename+"cost").val(),
             "Prereq": $(ename+"prereq").val(),


### PR DESCRIPTION
Fixes a typo (PokeEducation -> PokemonEducation), and increases the exported IDs of Edges and Abilities by 1, so the first Ability and Edge imports correctly into Roll10's PTU 1.0 sheets.